### PR TITLE
Update MySQL 5.6.37 to 5.7

### DIFF
--- a/m6/consul/dev-app.json
+++ b/m6/consul/dev-app.json
@@ -4,7 +4,7 @@
     "asg_min_size": "2",
     "rds_storage_size": "5",
     "rds_engine": "mysql",
-    "rds_version": "5.6.37",
+    "rds_version": "5.7",
     "rds_instance_size": "db.t2.micro",
     "rds_multi_az": "false",
     "rds_db_name": "wordpress"

--- a/m6/consul/prod-app.json
+++ b/m6/consul/prod-app.json
@@ -4,7 +4,7 @@
     "asg_min_size": "3",
     "rds_storage_size": "20",
     "rds_engine": "mysql",
-    "rds_version": "5.6.37",
+    "rds_version": "5.7",
     "rds_instance_size": "db.t2.micro",
     "rds_multi_az": "false",
     "rds_db_name": "wordpress"

--- a/m6/consul/qa-app.json
+++ b/m6/consul/qa-app.json
@@ -4,7 +4,7 @@
     "asg_min_size": "3",
     "rds_storage_size": "20",
     "rds_engine": "mysql",
-    "rds_version": "5.6.37",
+    "rds_version": "5.7",
     "rds_instance_size": "db.t2.micro",
     "rds_multi_az": "false",
     "rds_db_name": "wordpress"


### PR DESCRIPTION
Version 5.6.37 that is specified on the Consul json files is giving an InvalidParameterCombination error (see below). Changing to version 5.7 fixed it.

│ Error: Error creating DB Instance: InvalidParameterCombination: Cannot find version 5.6.37 for mysql
│       status code: 400, request id: 66a9bed1-0c9a-43a0-8eb8-f1e1b45b268d
│ 
│   with aws_db_instance.rds,
│   on resources.tf line 196, in resource "aws_db_instance" "rds":
│  196: resource "aws_db_instance" "rds" {
