### PR TITLE
Quote the query for getting public route table ID

### DIFF
--- a/m3/junior_admin.sh
+++ b/m3/junior_admin.sh
@@ -37,7 +37,7 @@ aws ec2 associate-route-table --route-table-id $priv_rt_id --subnet-id $priv_sub
 # Get the public route table
 pub_rt_id=$(aws ec2 describe-route-tables --filters Name="vpc-id",Values=$vpc_id \
   Name="tag:Name",Values="globo-primary-public" \
-  --query RouteTables[0].RouteTableId --output text)
+  --query 'RouteTables[0].RouteTableId' --output text)
 
 #Get the subnet ID for the public subnet
 pub_subnet_id=$(echo $pub_subnet | jq .Subnet.SubnetId -r)


### PR DESCRIPTION
- This prevents below error when running the command in ZSH:
  > zsh: no matches found: RouteTables[0].RouteTableId